### PR TITLE
Fixed Fatal error: Declaration must be compatible with Monolog\Handle…

### DIFF
--- a/src/KWPDOHandler.php
+++ b/src/KWPDOHandler.php
@@ -314,7 +314,7 @@ class KWPDOHandler extends AbstractProcessingHandler {
      * @param array $record
      * @return void
      */
-    protected function write(array $record)
+    protected function write(array $record) :void
     {
         if (!$this->initialized) {
             $this->initialize();


### PR DESCRIPTION
…r\AbstractProcessingHandler by add return type void to line 317 of KWPDOHandler.php

I got this error while trying to use this package on php 7.0.7